### PR TITLE
Prevent Makefile.PL from including Pod

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -57,15 +57,16 @@ WriteMakefile(
 # reroute the main POD into a separate README.pod if requested. This is here
 # purely to generate a README.pod for the github front page
 my $POD_header = <<EOF;
-=head1 OVERVIEW
+    =head1 OVERVIEW
 
-PDL::Graphics::Simple is a unified plotting interface for PDL.  The
-main distribution site is CPAN; the development repository is on
-github.com.
+    PDL::Graphics::Simple is a unified plotting interface for PDL.  The
+    main distribution site is CPAN; the development repository is on
+    github.com.
 
-=cut
+    =cut
 
 EOF
+$POD_header =~ s{^    }{}gm;
 
 if(exists $ARGV[0] && $ARGV[0] eq 'README.pod')
 {


### PR DESCRIPTION
The Makefile.PL has a pod fragment that it uses to generate the README.pod file. However, some tools (like metacpan) will see this as the Makefile.PL itself providing pod documentation. Avoid this by indenting the pod fragment, then stripping the indentation when it is used.