### PR TITLE
Use GPL v1 like Perl and PDL.

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -846,7 +846,7 @@ Craig DeForest, C<< <craig@deforest.org> >>
 Copyright 2013 Craig DeForest
 
 This program is free software; you can redistribute it and/or modify
-it under the terms of either: the Gnu General Public License v2 as
+it under the terms of either: the Gnu General Public License v1 as
 published by the Free Software Foundation; or the Perl Artistic
 License included with the Perl language.
 

--- a/lib/PDL/Graphics/Simple.pm
+++ b/lib/PDL/Graphics/Simple.pm
@@ -1567,7 +1567,7 @@ Craig DeForest, C<< <craig@deforest.org> >>
 Copyright 2013 Craig DeForest
 
 This program is free software; you can redistribute it and/or modify
-it under the terms of either: the Gnu General Public License v2 as
+it under the terms of either: the Gnu General Public License v1 as
 published by the Free Software Foundation; or the Perl Artistic
 License included with the Perl language.
 


### PR DESCRIPTION
The license mentioned in the source refers to GPL v2, but refers to https://dev.perl.org/licenses/ for more information which documents the Perl (and PDL) license as GPL v1 (or later) or the Artistic License.

This PR corrects the license mentioned in the README and source as GPL v1 to match Perl and PDL.